### PR TITLE
_options is undefined at our transport

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,7 +234,12 @@ module.exports = (function () {
 
         try {
           var _mailOpts = {};
-          if (transport.options.mailOptions) {
+
+          if (transport._options && typeof transport._options === 'object' && transport._options.mailOptions) {
+            _mailOpts = merge(_mailOpts, transport._options.mailOptions);
+          }
+
+          if (transport.options && typeof transport.options === 'object' && transport.options.mailOptions) {
             _mailOpts = merge(_mailOpts, transport.options.mailOptions);
           }
 

--- a/index.js
+++ b/index.js
@@ -234,8 +234,8 @@ module.exports = (function () {
 
         try {
           var _mailOpts = {};
-          if (transport._options.mailOptions) {
-            _mailOpts = merge(_mailOpts, transport._options.mailOptions);
+          if (transport.options.mailOptions) {
+            _mailOpts = merge(_mailOpts, transport.options.mailOptions);
           }
 
           if (task.mailOptions.length === 1) {


### PR DESCRIPTION
We have the following error thrown when using the default configuration shown in the doc. With the proposed changes Mail-Time is able to send emails via node-mailer. 

```
[mail-time] Exception during runtime: TypeError: Cannot read property 'mailOptions' of undefined
    at mail-time/index.js:237:33
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
[mail-time] Re-send Attempt #8, transport #0 to:  ***** TypeError: Cannot read property 'mailOptions' of undefined
    at mail-time/index.js:237:33
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```