### PR TITLE
Fix 'accepted' length checking for non-SMTP transports

### DIFF
--- a/index.js
+++ b/index.js
@@ -343,7 +343,7 @@ module.exports = class MailTime {
               return;
             }
 
-            if (!info.accepted.length) {
+            if (info.accepted && !info.accepted.length) {
               this.___handleError(task, 'Message not accepted or Greeting never received', info);
               return;
             }


### PR DESCRIPTION
This is a very simple fix to allow usage of non-SMTP transports, such as https://github.com/nodemailer/nodemailer-sendgrid

[Nodemailer's doc](https://nodemailer.com/usage/#sending-mail) states that the `info.accepted` must exist only if returned by SMTP transports. The `length` checking was breaking the package when this property was not available in the `info` returned by the custom transport.

I didn't create an issue for this, but I can do it if it needs further discussion.

Thanks.