### PR TITLE
Allow to concatEmails without sendAt stack problem

### DIFF
--- a/index.js
+++ b/index.js
@@ -439,7 +439,7 @@ module.exports = class MailTime {
         to: opts.to,
         isSent: false,
         sendAt: {
-          $lte: new Date(_sendAt + this.concatThrottling)
+          $lte: new Date(+_sendAt + this.concatThrottling)
         }
       }, {
         projection: {

--- a/index.js
+++ b/index.js
@@ -437,7 +437,10 @@ module.exports = class MailTime {
     if (this.concatEmails) {
       this.collection.findOne({
         to: opts.to,
-        isSent: false
+        isSent: false,
+        sendAt: {
+          $lte: new Date(_sendAt + this.concatThrottling)
+        }
       }, {
         projection: {
           _id: 1,


### PR DESCRIPTION
This little fix allow the use of concatEmail in combination with future sendAt emails.

The problem was due to the fact that if a email is already planned (exemple : sendAt = now + 2days), all mails will then stack to it. So the user will not get any emails UNTIL the planned one is gone.

To fix it, i've added a sendAt filter in the query to concat only mails in database which have sendAt to now + concatThrottling, this way, the query look for recents emails, and ignore stacking for planned emails.