### PR TITLE
feat: improve indices

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,12 +163,12 @@ module.exports = class MailTime {
     }
 
     this.collection = opts.db.collection('__mailTimeQueue__' + this.prefix);
-    this.collection.createIndex({ to: 1, isSent: 1, sendAt: 1 }, (indexError) => {
+    this.collection.createIndex({ isSent: 1, to: 1, sendAt: 1 }, (indexError) => {
       if (indexError) {
         _logError('[createIndex]', indexError);
       }
     });
-    this.collection.createIndex({ sendAt: 1, isSent: 1, tries: 1 }, { background: true }, (indexError) => {
+    this.collection.createIndex({ isSent: 1, sendAt: 1, tries: 1 }, { background: true }, (indexError) => {
       if (indexError) {
         _logError('[createIndex]', indexError);
       }


### PR DESCRIPTION
Change the order of indices to improve query performance. By making `isSent` the first index in the compound index we reduce the number of keys the database needs to go through.

Closes https://github.com/veliovgroup/mail-time/issues/34
